### PR TITLE
Got rid of offsetLeft error when charsToRemove is zero length and added ...

### DIFF
--- a/fancyInput.js
+++ b/fancyInput.js
@@ -11,9 +11,13 @@
 		isWebkit = 'webkitRequestAnimationFrame' in window,
 		letterHeight;
 
-	$.fn.fancyInput = function(){
+	$.fn.fancyInput = function(dest){
 		if( !isIe || 'ontouchstart' in document.documentElement )
-			init( this );
+			if (dest === true) {
+				destroy( this );
+			} else {
+				init( this );
+			}
 		return this;
 	}
 	
@@ -158,7 +162,7 @@
 				
 			if( range[1] - range[0] == 1 ){
 				charsToRemove.css('position','absolute');
-				if(isWebkit)
+				if(isWebkit && charsToRemove.length > 0)
 					charsToRemove[0].offsetLeft;
 				charsToRemove.addClass('deleted');
 				setTimeout(function(){
@@ -378,6 +382,17 @@
 			.on('keyup.fi select.fi mouseup.fi cut.fi paste.fi blur.fi', selector, fancyInput.allEvents)
 			.on('mousedown.fi mouseup.fi keydown.fi', selector, getSelectionDirection.set)
 			.on('keydown.fi', selector , fancyInput.keydown);
+	}
+
+
+	function destroy(inputs) {
+		var selector = inputs.selector;
+		$(document)
+			.off('input.fi', selector)
+			.off('keypress.fi', selector)
+			.off('keyup.fi select.fi mouseup.fi cut.fi paste.fi blur.fi', selector)
+			.off('mousedown.fi mouseup.fi keydown.fi', selector)
+			.off('keydown.fi', selector);
 	}
 
 	window.fancyInput = fancyInput;


### PR DESCRIPTION
...a destroy parameter to clear events. 

When hitting backspace on an empty input box I was getting "Uncaught TypeError: Cannot read property 'offsetLeft' of undefined" on line 166. So I'm checking charsToRemove for length now.

I also added a parameter called "dest" and a function called "destroy" that let you remove all events. This was needed for a project where fancyInput had to be initialized and de-initialized regularly. Without this, the key events were duplicating, causing characters to be typed multiple times because the events are assigned to the document. So simply setting a parameter to true clears the events immediately, like this:

$someInput.fancyInput(true);
